### PR TITLE
Add AJAX-based image upload

### DIFF
--- a/image2csv/urls.py
+++ b/image2csv/urls.py
@@ -3,31 +3,22 @@ URL configuration for image2csv project.
 
 The `urlpatterns` list routes URLs to views. For more information please see:
     https://docs.djangoproject.com/en/4.2/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-# image2csv/urls.py
+
 from django.contrib import admin
 from django.urls import path
 from django.contrib.auth import views as auth_views
-from uploader.views import upload_view, download_csv
+from uploader.views import upload_view, download_csv, process_image_ajax
 from django.conf import settings
 from django.conf.urls.static import static
-
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('login/', auth_views.LoginView.as_view(), name='login'),
-    path('logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),  # <--- Add this
+    path('logout/', auth_views.LogoutView.as_view(next_page='login'), name='logout'),
     path('download/', download_csv, name='download_csv'),
+    path('process-image/', process_image_ajax, name='process_image'),
     path('', upload_view, name='home'),
 ]
+
 urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/uploader/static/uploader/upload.js
+++ b/uploader/static/uploader/upload.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.getElementById('upload-form');
+  const processing = document.getElementById('processing');
+
+  if (!form) return;
+
+  function getCookie(name) {
+    let cookieValue = null;
+    if (document.cookie && document.cookie !== '') {
+      const cookies = document.cookie.split(';');
+      for (let i = 0; i < cookies.length; i++) {
+        const cookie = cookies[i].trim();
+        if (cookie.substring(0, name.length + 1) === (name + '=')) {
+          cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+          break;
+        }
+      }
+    }
+    return cookieValue;
+  }
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    const csrftoken = getCookie('csrftoken');
+    const formData = new FormData(form);
+    processing.style.display = 'block';
+    fetch('/process-image/', {
+      method: 'POST',
+      headers: {
+        'X-CSRFToken': csrftoken
+      },
+      body: formData
+    })
+      .then(response => response.json())
+      .then(data => {
+        processing.style.display = 'none';
+        if (data.csv_data) {
+          const blob = new Blob([data.csv_data], { type: 'text/csv' });
+          const url = window.URL.createObjectURL(blob);
+          const a = document.createElement('a');
+          a.href = url;
+          a.download = 'table.csv';
+          a.click();
+          window.URL.revokeObjectURL(url);
+        } else if (data.error) {
+          alert(data.error);
+        }
+      })
+      .catch(() => {
+        processing.style.display = 'none';
+        alert('An error occurred while processing the image.');
+      });
+  });
+});

--- a/uploader/templates/uploader/upload.html
+++ b/uploader/templates/uploader/upload.html
@@ -1,18 +1,20 @@
 <!-- uploader/templates/uploader/upload.html -->
 {% extends "base.html" %}
+{% load static %}
 
 {% block content %}
 {% if user.is_authenticated %}
 <div class="upload-container">
     <div class="upload-form">
         <h2>Upload Image</h2>
-        <form method="post" enctype="multipart/form-data">
+        <form id="upload-form" method="post" enctype="multipart/form-data">
             {% csrf_token %}
             <div class="form-fields">
                 {{ form.as_p }}
             </div>
             <button type="submit" class="upload-btn">Upload Image</button>
         </form>
+        <div id="processing" style="display:none;margin-top:10px;">Processing...</div>
     </div>
 </div>
 <style>
@@ -80,4 +82,5 @@
     }
 </style>
 {% endif %}
+<script src="{% static 'uploader/upload.js' %}"></script>
 {% endblock %}

--- a/uploader/views.py
+++ b/uploader/views.py
@@ -1,53 +1,64 @@
-from django.shortcuts import render
-
-# Create your views here.
-# uploader/views.py
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render, redirect
+from django.http import HttpResponse, JsonResponse
+from django.shortcuts import render
 from .forms import ImageUploadForm
-from django.http import HttpResponse
 import openai
 import base64
 import os
 from dotenv import load_dotenv
+
 # Load environment variables from .env file
 load_dotenv()
 API_KEY = os.getenv('OPENAI_API_KEY')
 
+
 @login_required
 def upload_view(request):
-    if request.method == 'POST':
-        form = ImageUploadForm(request.POST, request.FILES)
-        if form.is_valid():
-            image = request.FILES['image']
-            b64_img = base64.b64encode(image.read()).decode('utf-8')
+    """Render the upload page."""
+    form = ImageUploadForm()
+    return render(request, "uploader/upload.html", {"form": form})
 
-            # OpenAI Vision API using new format
-            client = openai.OpenAI(api_key=API_KEY)
-            response = client.responses.create(
-                model="o4-mini-2025-04-16",
-                input=[
+
+@login_required
+def process_image_ajax(request):
+    """Handle AJAX image uploads and return CSV data as JSON."""
+    if request.method != "POST":
+        return JsonResponse({"error": "Invalid request"}, status=400)
+
+    form = ImageUploadForm(request.POST, request.FILES)
+    if not form.is_valid():
+        return JsonResponse({"error": "Invalid form"}, status=400)
+
+    image = request.FILES["image"]
+    b64_img = base64.b64encode(image.read()).decode("utf-8")
+
+    # OpenAI Vision API using new format
+    client = openai.OpenAI(api_key=API_KEY)
+    response = client.responses.create(
+        model="o4-mini-2025-04-16",
+        input=[
+            {
+                "role": "user",
+                "content": [
                     {
-                        "role": "user",
-                        "content": [
-                            {"type": "input_text", "text": "Can you please transcribe this table and return it in csv format?"},
-                            {"type": "input_image", "image_url": f"data:image/jpeg;base64,{b64_img}"}
-                        ],
-                    }
+                        "type": "input_text",
+                        "text": "Can you please transcribe this table and return it in csv format?",
+                    },
+                    {"type": "input_image", "image_url": f"data:image/jpeg;base64,{b64_img}"},
                 ],
-            )
-            csv_data = response.output_text
-            print(f"Received CSV data from ChatGPT: {csv_data}")
+            }
+        ],
+    )
 
-            request.session['csv_data'] = csv_data
-            return redirect('download_csv')
-    else:
-        form = ImageUploadForm()
-    return render(request, 'uploader/upload.html', {'form': form})
+    csv_data = response.output_text
+    print(f"Received CSV data from ChatGPT: {csv_data}")
+
+    return JsonResponse({"csv_data": csv_data})
+
 
 @login_required
 def download_csv(request):
-    csv_data = request.session.get('csv_data', '')
-    response = HttpResponse(csv_data, content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename="table.csv"'
+    csv_data = request.session.get("csv_data", "")
+    response = HttpResponse(csv_data, content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="table.csv"'
     return response


### PR DESCRIPTION
## Summary
- create async image processing endpoint and hook up new URL
- add JS for AJAX form submission and CSV download
- update upload template to use the script

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_687ed0e7c680832f9e354366c1764cb3